### PR TITLE
Docker non root

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ nginx -s reload
 
 ## Update base image
 
-The `entity-api`, `uuid-api`, `ingest-api`, and `hubmap-auth` docker images are based on the `hubmap/api-base-image:latest` image. If you need to update the base image, go to the `api-base-image` directory and recrerate it with:
+The `entity-api`, `uuid-api`, `ingest-api`, `ingest-ui`, and `hubmap-auth` docker images are based on the `hubmap/api-base-image:latest` image. If you need to update the base image, go to the `api-base-image` directory and recrerate it with:
 
 ````
 sudo docker build -t hubmap/api-base-image:latest

--- a/api-base-image/Dockerfile
+++ b/api-base-image/Dockerfile
@@ -1,8 +1,7 @@
 # Parent image
 FROM centos:7
 
-LABEL description="HuBMAP Docker Base Image" \
-	version="1.0"
+LABEL description="HuBMAP Docker Base Image"
 
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
 # 1 - Update the package listings
@@ -16,3 +15,11 @@ RUN yum update -y && \
     pip3 install --upgrade pip && \
     yum clean all 
 
+# Install gosu for de-elevating root to hubmap user
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64" && \
+    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64.asc" && \
+    gpg --verify /usr/local/bin/gosu.asc && \
+    rm /usr/local/bin/gosu.asc && \
+    rm -r /root/.gnupg/ && \
+    chmod +x /usr/local/bin/gosu

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,25 +7,25 @@ services:
     # Each API has its dedicated port and needs to be mapped here
     ports:
       # hubmap-auth
-      - "8080:80" 
+      - "8080:8080" 
       # assets
-      - "8181:81"
+      - "8181:8181"
       # uuid-api
-      - "8282:82" 
+      - "8282:8282" 
       # entity-api
-      - "8383:83" 
+      - "8383:8383" 
       # ingest-api
-      - "8484:84" 
+      - "8484:8484" 
       # ingest-ui
-      - "8585:85" 
+      - "8585:8585" 
     volumes:
       # Mount the source code to container
-      - "./hubmap-auth/src/:/home/hubmap/src"
+      - "./hubmap-auth/src/:/usr/src/app/src"
       # Mount conf.d-dev to the nginx conf.d on container
       - "./nginx/conf.d-dev:/etc/nginx/conf.d"
       # Mount the static files
       - "/usr/local/src/hubmap/assets:/usr/src/assets"
       # Mount the API endpoints json file for API endpoints lookup
-      - "./api_endpoints.dev.json:/home/hubmap/api_endpoints.json"
+      - "./api_endpoints.dev.json:/usr/src/app/api_endpoints.json"
       # Mount the secured_datasets json file for dataset files lookup
-      - "./secured_datasets.json:/home/hubmap/secured_datasets.json"
+      - "./secured_datasets.json:/usr/src/app/secured_datasets.json"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,12 +20,12 @@ services:
       - "8585:85" 
     volumes:
       # Mount the source code to container
-      - "./hubmap-auth/src/:/usr/src/app/src"
+      - "./hubmap-auth/src/:/home/hubmap/src"
       # Mount conf.d-dev to the nginx conf.d on container
       - "./nginx/conf.d-dev:/etc/nginx/conf.d"
       # Mount the static files
       - "/usr/local/src/hubmap/assets:/usr/src/assets"
       # Mount the API endpoints json file for API endpoints lookup
-      - "./api_endpoints.dev.json:/usr/src/app/api_endpoints.json"
+      - "./api_endpoints.dev.json:/home/hubmap/api_endpoints.json"
       # Mount the secured_datasets json file for dataset files lookup
-      - "./secured_datasets.json:/usr/src/app/secured_datasets.json"
+      - "./secured_datasets.json:/home/hubmap/secured_datasets.json"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,8 @@ services:
   hubmap-auth:
     # Mapping ports in the HOST:CONTAINER format
     # Each API has its dedicated port and needs to be mapped here
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     ports:
       # hubmap-auth
       - "8080:8080" 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,8 +9,8 @@ services:
     restart: always
     # Map host machine port 80, 443, and 8443 to container ports
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:9443"
       - "8443:8443"
     volumes:
       # Mount the app config to container in order to keep it outside of the image

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,9 +8,12 @@ services:
     # Specifying a restart policy to avoid downtime
     restart: always
     # Map host machine port 80, 443, and 8443 to container ports
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     ports:
       - "80:8080"
-      - "443:9443"
+      - "443:4430"
+      # 8443 is used by ingest-api running on another machine
       - "8443:8443"
     volumes:
       # Mount the app config to container in order to keep it outside of the image

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,8 +9,8 @@ services:
     restart: always
     # Map host machine port 80, 443, and 8443 to container ports
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:9443"
       - "8443:8443" 
     volumes:
       # Mount the source code to container

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,9 +8,12 @@ services:
     # Specifying a restart policy to avoid downtime
     restart: always
     # Map host machine port 80, 443, and 8443 to container ports
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     ports:
       - "80:8080"
-      - "443:9443"
+      - "443:4430"
+      # 8443 is used by ingest-api running on another machine
       - "8443:8443" 
     volumes:
       # Mount the source code to container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,18 @@ services:
   hubmap-auth:
     build: ./hubmap-auth
     # Build the image with name and tag
-    image: hubmap-auth:1.0
+    image: hubmap-auth:1.1
     hostname: hubmap-auth
     container_name: hubmap-auth
     networks:
       - gateway_hubmap
     volumes:
-      # Make the uwsgi logging generated on container available through from host
-      - "./hubmap-auth/log:/usr/src/app/log"
+      # Make the uwsgi/nginx log files generated on container available through from host
+      - "./logs:/home/hubmap/logs"
       # favicon.ico
       - "./nginx/html:/usr/share/nginx/html"
+      # Example data volume mount
+      - "./data:/home/hubmap/data"
 
 networks:
   # This is the network created by gateway to enable communicaton between multiple docker-compose projects

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     hostname: hubmap-auth
     container_name: hubmap-auth
     environment:
+      - HOST_GID=1000
       - HOST_UID=1000
     networks:
       - gateway_hubmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,15 @@ services:
     image: hubmap-auth:1.1
     hostname: hubmap-auth
     container_name: hubmap-auth
+    environment:
+      - HOST_UID=1000
     networks:
       - gateway_hubmap
     volumes:
       # Make the uwsgi/nginx log files generated on container available through from host
-      - "./logs:/home/hubmap/logs"
+      - "./hubmap-auth/log:/usr/src/app/log"
       # favicon.ico
       - "./nginx/html:/usr/share/nginx/html"
-      # Example data volume mount
-      - "./data:/home/hubmap/data"
 
 networks:
   # This is the network created by gateway to enable communicaton between multiple docker-compose projects

--- a/hubmap-auth/Dockerfile
+++ b/hubmap-auth/Dockerfile
@@ -3,14 +3,10 @@ FROM hubmap/api-base-image:latest
 
 LABEL description="HuBMAP Authentication and Authorization Service"
 
-# Add the hubmap user UID:9000, GID:9000
-# Add hubmap to sudoers
-RUN groupadd --gid 9000 hubmap && \
-    useradd --uid 9000 --gid 9000 hubmap && \
-    usermod -aG wheel hubmap
+WORKDIR /usr/src/app
 
-# Require no password for hubmap sudo
-COPY sudoers.txt /etc/sudoers
+# Copy from host to image
+COPY . .
 
 # Nginx package from EPEL is old, we create a new repository file to install the latest mainline version of Nginx
 RUN echo $'[nginx-mainline]\n\
@@ -21,38 +17,27 @@ enabled=1\n'\
 >> /etc/yum.repos.d/nginx.repo
 
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
-# 1 - Update the package listings
-# 2 - Install nginx (using the custom yum repo specified earlier) and sudo
-# 3 - Remove the default nginx config file
-# 4 - Clean all yum cache
-RUN yum update -y && \
-    yum install -y nginx sudo && \
+# 1 - Install nginx (using the custom yum repo specified earlier) and git (for pip installing HuBMAP commons from github)
+# 2 - Remove the default nginx config file
+# 3 - Install flask app dependencies with pip (pip3 also works)
+# 4 - Make the start script executable
+# 5 - Clean all yum cache
+RUN yum install -y nginx && \
     rm /etc/nginx/conf.d/default.conf && \
+    mv nginx.conf /etc/nginx/nginx.conf && \
+    pip install -r src/requirements.txt && \
+    chmod +x start.sh && \
     yum clean all 
-
-# Specify the user to execute all commands below
-USER hubmap
-
-# Change dir to avoid permission issue
-WORKDIR /home/hubmap
-
-# Copy from host to image
-COPY . .
-
-# 1 - Install flask app dependencies with pip (pip3 also works)
-# 2 - Change ownership of the start script
-# 3 - Make the start script executable
-RUN sudo pip install -r src/requirements.txt && \
-    sudo chown hubmap:hubmap start.sh && \
-    chmod +x start.sh
-
-# Create directories for data and logs mounted volumes
-RUN mkdir data && \
-    mkdir logs
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # EXPOSE does not make the ports of the container accessible to the host.
 # Here 5000 is for the uwsgi socket, 80 for nginx
 EXPOSE 5000 80
+
+# Set an entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD ["./start.sh"]

--- a/hubmap-auth/Dockerfile
+++ b/hubmap-auth/Dockerfile
@@ -19,9 +19,10 @@ enabled=1\n'\
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
 # 1 - Install nginx (using the custom yum repo specified earlier) and git (for pip installing HuBMAP commons from github)
 # 2 - Remove the default nginx config file
-# 3 - Install flask app dependencies with pip (pip3 also works)
-# 4 - Make the start script executable
-# 5 - Clean all yum cache
+# 3 - Overwrite the nginx.conf with ours to run nginx as non-root
+# 4 - Install flask app dependencies with pip (pip3 also works)
+# 5 - Make the start script executable
+# 6 - Clean all yum cache
 RUN yum install -y nginx && \
     rm /etc/nginx/conf.d/default.conf && \
     mv nginx.conf /etc/nginx/nginx.conf && \

--- a/hubmap-auth/Dockerfile
+++ b/hubmap-auth/Dockerfile
@@ -1,13 +1,16 @@
 # Parent image
 FROM hubmap/api-base-image:latest
 
-LABEL description="HuBMAP Authentication and Authorization Service" \
-	version="1.0"
+LABEL description="HuBMAP Authentication and Authorization Service"
 
-WORKDIR /usr/src/app
+# Add the hubmap user UID:9000, GID:9000
+# Add hubmap to sudoers
+RUN groupadd --gid 9000 hubmap && \
+    useradd --uid 9000 --gid 9000 hubmap && \
+    usermod -aG wheel hubmap
 
-# Copy from host to image
-COPY . .
+# Require no password for hubmap sudo
+COPY sudoers.txt /etc/sudoers
 
 # Nginx package from EPEL is old, we create a new repository file to install the latest mainline version of Nginx
 RUN echo $'[nginx-mainline]\n\
@@ -19,19 +22,33 @@ enabled=1\n'\
 
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
 # 1 - Update the package listings
-# 2 - Install nginx (using the custom yum repo specified earlier) and git (for pip installing HuBMAP commons from github)
+# 2 - Install nginx (using the custom yum repo specified earlier) and sudo
 # 3 - Remove the default nginx config file
-# 4 - Install Extra Packages for Enterprise Linux (EPEL) 
-# 5 - Use the EPEL repo for installing python, pip, uwsgi, uwsgi python plugin
-# 6 - Upgrade pip, after upgrading, both pip and pip3 are the same version
-# 7 - Install flask app dependencies with pip (pip3 also works)
-# 8 - Make the start script executable
-# 9 - Clean all yum cache
-RUN yum install -y nginx && \
+# 4 - Clean all yum cache
+RUN yum update -y && \
+    yum install -y nginx sudo && \
     rm /etc/nginx/conf.d/default.conf && \
-    pip install -r src/requirements.txt && \
-    chmod +x start.sh && \
     yum clean all 
+
+# Specify the user to execute all commands below
+USER hubmap
+
+# Change dir to avoid permission issue
+WORKDIR /home/hubmap
+
+# Copy from host to image
+COPY . .
+
+# 1 - Install flask app dependencies with pip (pip3 also works)
+# 2 - Change ownership of the start script
+# 3 - Make the start script executable
+RUN sudo pip install -r src/requirements.txt && \
+    sudo chown hubmap:hubmap start.sh && \
+    chmod +x start.sh
+
+# Create directories for data and logs mounted volumes
+RUN mkdir data && \
+    mkdir logs
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # EXPOSE does not make the ports of the container accessible to the host.

--- a/hubmap-auth/README.md
+++ b/hubmap-auth/README.md
@@ -10,6 +10,9 @@ The Flask application confiuration file `app.cfg` is located under `instance` fo
 # File path of API endpoints json file, DO NOT MODIFY
 API_ENDPOINTS_FILE = '/usr/src/app/api_endpoints.json'
 
+# File path of the secured datasets
+SECURED_DATASETS_FILE = '/usr/src/app/secured_datasets.json'
+
 # Globus app client ID and secret
 GLOBUS_APP_ID = ''
 GLOBUS_APP_SECRET = ''

--- a/hubmap-auth/entrypoint.sh
+++ b/hubmap-auth/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# defaulting to 9000 if it doesn't exist
+HOST_UID=${HOST_UID:-9000}
+
+echo "Starting hubmap-auth container with the same host UID: $HOST_UID"
+
+# Create a new user with the same host UID to run processes on container
+# The Filesystem doesn't really care what the user is called,
+# it only cares about the UID attached to that user
+useradd -r -u $HOST_UID -o -c "" -m hubmap
+
+# When running Nginx as a non-root user, we need to create the pid file
+# and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
+# In individual nginx *.conf, also don't listen on ports 80 or 443 because 
+# only root processes can listen to ports below 1024
+touch /var/run/nginx.pid
+chown -R hubmap /var/run/nginx.pid
+chown -R hubmap /var/cache/nginx
+chown -R hubmap /var/log/nginx
+
+# Lastly we use gosu to execute our process "$@" as that user
+# Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
+# "$@" is a shell variable that means "all the arguments"
+exec /usr/local/bin/gosu hubmap "$@"

--- a/hubmap-auth/entrypoint.sh
+++ b/hubmap-auth/entrypoint.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 
-# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose,
 # defaulting to 9000 if it doesn't exist
+HOST_GID=${HOST_GID:-9000}
 HOST_UID=${HOST_UID:-9000}
 
-echo "Starting hubmap-auth container with the same host UID: $HOST_UID"
+echo "Starting hubmap-auth container with the same host user UID: $HOST_UID and GID: $HOST_GID"
 
 # Create a new user with the same host UID to run processes on container
 # The Filesystem doesn't really care what the user is called,
 # it only cares about the UID attached to that user
-useradd -r -u $HOST_UID -o -c "" -m hubmap
+# Check if user already exists and don't recreate across container restarts
+getent passwd $HOST_UID > /dev/null 2&>1
+# $? is a special variable that captures the exit status of last task
+if [ $? -ne 0 ]; then
+    groupadd -r -g $HOST_GID hubmap
+    useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
+fi
 
 # When running Nginx as a non-root user, we need to create the pid file
 # and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
 # In individual nginx *.conf, also don't listen on ports 80 or 443 because 
 # only root processes can listen to ports below 1024
 touch /var/run/nginx.pid
-chown -R hubmap /var/run/nginx.pid
-chown -R hubmap /var/cache/nginx
-chown -R hubmap /var/log/nginx
+chown -R hubmap:hubmap /var/run/nginx.pid
+chown -R hubmap:hubmap /var/cache/nginx
+chown -R hubmap:hubmap /var/log/nginx
 
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments

--- a/hubmap-auth/log/README.md
+++ b/hubmap-auth/log/README.md
@@ -1,1 +1,0 @@
-# Mounted volume for uwsgi logging

--- a/hubmap-auth/nginx.conf
+++ b/hubmap-auth/nginx.conf
@@ -1,0 +1,33 @@
+# The only change needed is to comment out the user nginx; line 
+# to avoid a warning since this directive is only meaningfull when Nginx is running as root
+# user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/hubmap-auth/src/app.py
+++ b/hubmap-auth/src/app.py
@@ -33,8 +33,8 @@ cache = TTLCache(maxsize=app.config['CACHE_MAXSIZE'], ttl=app.config['CACHE_TTL'
 
 @app.route('/', methods = ['GET'])
 def home():
-    os.makedirs('/home/hubmap/test_dir/44')
-    os.mknod("/home/hubmap/test_dir/newfile.txt")
+    os.makedirs('/home/hubmap/data/test')
+    os.mknod("/home/hubmap/data/test/test.txt")
     return "This is HuBMAP Web Gateway :)"
 
 

--- a/hubmap-auth/src/app.py
+++ b/hubmap-auth/src/app.py
@@ -7,6 +7,9 @@ import functools
 import re
 import os
 
+# For testing mkdir
+import pathlib
+
 # HuBMAP commons
 from hubmap_commons.hm_auth import AuthHelper
 
@@ -33,8 +36,6 @@ cache = TTLCache(maxsize=app.config['CACHE_MAXSIZE'], ttl=app.config['CACHE_TTL'
 
 @app.route('/', methods = ['GET'])
 def home():
-    os.makedirs('/home/hubmap/data/test')
-    os.mknod("/home/hubmap/data/test/test.txt")
     return "This is HuBMAP Web Gateway :)"
 
 

--- a/hubmap-auth/src/app.py
+++ b/hubmap-auth/src/app.py
@@ -33,6 +33,8 @@ cache = TTLCache(maxsize=app.config['CACHE_MAXSIZE'], ttl=app.config['CACHE_TTL'
 
 @app.route('/', methods = ['GET'])
 def home():
+    os.makedirs('/home/hubmap/test_dir/44')
+    os.mknod("/home/hubmap/test_dir/newfile.txt")
     return "This is HuBMAP Web Gateway :)"
 
 

--- a/hubmap-auth/src/uwsgi.ini
+++ b/hubmap-auth/src/uwsgi.ini
@@ -3,18 +3,14 @@
 # If uwsgi installed with pip, no need this
 plugin = python36
 
-# Run uwsgi as hubmap instead of root
-uid = 9000
-gid = 9000
-
 # So uwsgi knows where to mount the app
-chdir = /home/hubmap/src
+chdir = /usr/src/app/src
 
 # Application's callbale
 module = wsgi:application
 
 # Location of uwsgi log file
-logto = /home/hubmap/logs/uwsgi-hubmap-auth.log
+logto = /usr/src/app/log/uwsgi-hubmap-auth.log
 
 # Master with 2 worker process (based on CPU number)
 master = true

--- a/hubmap-auth/src/uwsgi.ini
+++ b/hubmap-auth/src/uwsgi.ini
@@ -3,14 +3,18 @@
 # If uwsgi installed with pip, no need this
 plugin = python36
 
+# Run uwsgi as hubmap instead of root
+#uid = 9000
+#gid = 9000
+
 # So uwsgi knows where to mount the app
-chdir = /usr/src/app/src
+chdir = /home/hubmap/src
 
 # Application's callbale
 module = wsgi:application
 
 # Location of uwsgi log file
-logto = /usr/src/app/log/uwsgi-hubmap-auth.log
+logto = /home/hubmap/logs/uwsgi-hubmap-auth.log
 
 # Master with 2 worker process (based on CPU number)
 master = true

--- a/hubmap-auth/src/uwsgi.ini
+++ b/hubmap-auth/src/uwsgi.ini
@@ -4,8 +4,8 @@
 plugin = python36
 
 # Run uwsgi as hubmap instead of root
-#uid = 9000
-#gid = 9000
+uid = 9000
+gid = 9000
 
 # So uwsgi knows where to mount the app
 chdir = /home/hubmap/src

--- a/hubmap-auth/start.sh
+++ b/hubmap-auth/start.sh
@@ -2,7 +2,7 @@
 
 # Start nginx in background
 # 'daemon off;' is nginx configuration directive
-sudo nginx -g 'daemon off;' &
+nginx -g 'daemon off;' &
 
 # Start uwsgi and keep it running in foreground
-sudo uwsgi --ini /home/hubmap/src/uwsgi.ini
+uwsgi --ini /usr/src/app/src/uwsgi.ini

--- a/hubmap-auth/start.sh
+++ b/hubmap-auth/start.sh
@@ -5,4 +5,4 @@
 sudo nginx -g 'daemon off;' &
 
 # Start uwsgi and keep it running in foreground
-uwsgi --ini /home/hubmap/src/uwsgi.ini
+sudo uwsgi --ini /home/hubmap/src/uwsgi.ini

--- a/hubmap-auth/start.sh
+++ b/hubmap-auth/start.sh
@@ -2,7 +2,7 @@
 
 # Start nginx in background
 # 'daemon off;' is nginx configuration directive
-nginx -g 'daemon off;' &
+sudo nginx -g 'daemon off;' &
 
 # Start uwsgi and keep it running in foreground
-uwsgi --ini /usr/src/app/src/uwsgi.ini
+uwsgi --ini /home/hubmap/src/uwsgi.ini

--- a/hubmap-auth/sudoers.txt
+++ b/hubmap-auth/sudoers.txt
@@ -1,0 +1,2 @@
+root ALL=(ALL) ALL
+hubmap ALL=(ALL) NOPASSWD: ALL

--- a/hubmap-auth/sudoers.txt
+++ b/hubmap-auth/sudoers.txt
@@ -1,2 +1,0 @@
-root ALL=(ALL) ALL
-hubmap ALL=(ALL) NOPASSWD: ALL

--- a/nginx/conf.d-dev/assets.conf
+++ b/nginx/conf.d-dev/assets.conf
@@ -1,13 +1,13 @@
 server {
     # The hubmap-auth service listens port 81 on it's container
-    listen 81;
+    listen 8181;
     
     server_name localhost;
     root /usr/src/assets;
 
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_assets.log;
-    error_log /home/hubmap/logs/nginx_error_assets.log warn;
+    access_log /usr/src/app/log/nginx_access_assets.log;
+    error_log /usr/src/app/log/nginx_error_assets.log warn;
     
     location = /favicon.ico {
         alias /usr/share/nginx/html/favicon.ico;

--- a/nginx/conf.d-dev/assets.conf
+++ b/nginx/conf.d-dev/assets.conf
@@ -1,5 +1,7 @@
+# Port 8181 on host maps to 8181 on container
 server {
-    # The hubmap-auth service listens port 81 on it's container
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8181;
     
     server_name localhost;

--- a/nginx/conf.d-dev/assets.conf
+++ b/nginx/conf.d-dev/assets.conf
@@ -6,8 +6,8 @@ server {
     root /usr/src/assets;
 
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_assets.log;
-    error_log /usr/src/app/log/nginx_error_assets.log warn;
+    access_log /home/hubmap/logs/nginx_access_assets.log;
+    error_log /home/hubmap/logs/nginx_error_assets.log warn;
     
     location = /favicon.ico {
         alias /usr/share/nginx/html/favicon.ico;

--- a/nginx/conf.d-dev/entity-api.conf
+++ b/nginx/conf.d-dev/entity-api.conf
@@ -1,13 +1,13 @@
 server {
     # The port exposed on `hubmap-auth` container for nginx
-    listen 83;
+    listen 8383;
     
     server_name localhost;
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_entity-api.log;
-    error_log /home/hubmap/logs/nginx_error_entity-api.log warn;
+    access_log /usr/src/app/log/nginx_access_entity-api.log;
+    error_log /usr/src/app/log/nginx_error_entity-api.log warn;
 
     # No auth_request for favicon    
     location = /favicon.ico {

--- a/nginx/conf.d-dev/entity-api.conf
+++ b/nginx/conf.d-dev/entity-api.conf
@@ -6,8 +6,8 @@ server {
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_entity-api.log;
-    error_log /usr/src/app/log/nginx_error_entity-api.log warn;
+    access_log /home/hubmap/logs/nginx_access_entity-api.log;
+    error_log /home/hubmap/logs/nginx_error_entity-api.log warn;
 
     # No auth_request for favicon    
     location = /favicon.ico {

--- a/nginx/conf.d-dev/entity-api.conf
+++ b/nginx/conf.d-dev/entity-api.conf
@@ -1,5 +1,7 @@
+# Port 8383 on host maps to 8383 on container
 server {
-    # The port exposed on `hubmap-auth` container for nginx
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8383;
     
     server_name localhost;

--- a/nginx/conf.d-dev/hubmap-auth.conf
+++ b/nginx/conf.d-dev/hubmap-auth.conf
@@ -1,21 +1,21 @@
 # Define the upstream hubmap-auth server to be used by other API nginx configs
 # This sever will be accessed via `http://hubmap-auth-server/api_auth` in other conf files
-# We use "localhost:80" because port 80 is exposed on `hubmap-auth` container for nginx
+# We use "localhost:8080" because port 8080 is exposed on `hubmap-auth` container for nginx
 upstream hubmap-auth-server {
     # hubmap-auth:80/api_auth is invalid syntax
-    server localhost:80;
+    server localhost:8080;
 }
 
 server {
     # The hubmap-auth service listens port 80 on it's container
-    listen 80;
+    listen 8080;
     
     server_name localhost;
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_gateway.log;
-    error_log /home/hubmap/logs/nginx_error_gateway.log warn;
+    access_log /usr/src/app/log/nginx_access_gateway.log;
+    error_log /usr/src/app/log/nginx_error_gateway.log warn;
     
     location = /favicon.ico {
         alias /usr/share/nginx/html/favicon.ico;

--- a/nginx/conf.d-dev/hubmap-auth.conf
+++ b/nginx/conf.d-dev/hubmap-auth.conf
@@ -2,12 +2,14 @@
 # This sever will be accessed via `http://hubmap-auth-server/api_auth` in other conf files
 # We use "localhost:8080" because port 8080 is exposed on `hubmap-auth` container for nginx
 upstream hubmap-auth-server {
-    # hubmap-auth:80/api_auth is invalid syntax
+    # hubmap-auth:8080/api_auth is invalid syntax
     server localhost:8080;
 }
 
+# Port 8080 on host maps to 8080 on container
 server {
-    # The hubmap-auth service listens port 80 on it's container
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     
     server_name localhost;

--- a/nginx/conf.d-dev/hubmap-auth.conf
+++ b/nginx/conf.d-dev/hubmap-auth.conf
@@ -14,8 +14,8 @@ server {
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_gateway.log;
-    error_log /usr/src/app/log/nginx_error_gateway.log warn;
+    access_log /home/hubmap/logs/nginx_access_gateway.log;
+    error_log /home/hubmap/logs/nginx_error_gateway.log warn;
     
     location = /favicon.ico {
         alias /usr/share/nginx/html/favicon.ico;

--- a/nginx/conf.d-dev/ingest-api.conf
+++ b/nginx/conf.d-dev/ingest-api.conf
@@ -1,13 +1,13 @@
 server {
     # The port exposed on `hubmap-auth` container for nginx
-    listen 84;
+    listen 8484;
     
     server_name localhost;
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_ingest-api.log;
-    error_log /home/hubmap/logs/nginx_error_ingest-api.log warn;
+    access_log /usr/src/app/log/nginx_access_ingest-api.log;
+    error_log /usr/src/app/log/nginx_error_ingest-api.log warn;
 
     # Allows file uploads up to 500 megabytes
     client_max_body_size 500M;

--- a/nginx/conf.d-dev/ingest-api.conf
+++ b/nginx/conf.d-dev/ingest-api.conf
@@ -1,5 +1,7 @@
+# Port 8484 on host maps to 8484 on container
 server {
-    # The port exposed on `hubmap-auth` container for nginx
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8484;
     
     server_name localhost;

--- a/nginx/conf.d-dev/ingest-api.conf
+++ b/nginx/conf.d-dev/ingest-api.conf
@@ -6,8 +6,8 @@ server {
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_ingest-api.log;
-    error_log /usr/src/app/log/nginx_error_ingest-api.log warn;
+    access_log /home/hubmap/logs/nginx_access_ingest-api.log;
+    error_log /home/hubmap/logs/nginx_error_ingest-api.log warn;
 
     # Allows file uploads up to 500 megabytes
     client_max_body_size 500M;

--- a/nginx/conf.d-dev/ingest-ui.conf
+++ b/nginx/conf.d-dev/ingest-ui.conf
@@ -1,12 +1,12 @@
 server {
     # The port exposed on `hubmap-auth` container for nginx
-    listen 85;
+    listen 8585;
     
     server_name localhost;
 
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_ingest-ui.log;
-    error_log /home/hubmap/logs/nginx_error_ingest-ui.log warn; 
+    access_log /usr/src/app/log/nginx_access_ingest-ui.log;
+    error_log /usr/src/app/log/nginx_error_ingest-ui.log warn; 
 
     location / {
         proxy_pass http://ingest-ui;

--- a/nginx/conf.d-dev/ingest-ui.conf
+++ b/nginx/conf.d-dev/ingest-ui.conf
@@ -9,6 +9,7 @@ server {
     error_log /usr/src/app/log/nginx_error_ingest-ui.log warn; 
 
     location / {
-        proxy_pass http://ingest-ui;
+        # ingest-ui nginx runs as non-root, using port 8080
+        proxy_pass http://ingest-ui:8080;
     }
 }

--- a/nginx/conf.d-dev/ingest-ui.conf
+++ b/nginx/conf.d-dev/ingest-ui.conf
@@ -5,8 +5,8 @@ server {
     server_name localhost;
 
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_ingest-ui.log;
-    error_log /usr/src/app/log/nginx_error_ingest-ui.log warn; 
+    access_log /home/hubmap/logs/nginx_access_ingest-ui.log;
+    error_log /home/hubmap/logs/nginx_error_ingest-ui.log warn; 
 
     location / {
         proxy_pass http://ingest-ui;

--- a/nginx/conf.d-dev/ingest-ui.conf
+++ b/nginx/conf.d-dev/ingest-ui.conf
@@ -1,5 +1,7 @@
+# Port 8585 on host maps to 8585 on container
 server {
-    # The port exposed on `hubmap-auth` container for nginx
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8585;
     
     server_name localhost;

--- a/nginx/conf.d-dev/uuid-api.conf
+++ b/nginx/conf.d-dev/uuid-api.conf
@@ -5,14 +5,14 @@ upstream uuid-api-server {
 
 server {
     # The port exposed on `hubmap-auth` container for nginx
-    listen 82;
+    listen 8282;
     
     server_name localhost;
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_uuid-api.log;
-    error_log /home/hubmap/logs/nginx_error_uuid-api.log warn;
+    access_log /usr/src/app/log/nginx_access_uuid-api.log;
+    error_log /usr/src/app/log/nginx_error_uuid-api.log warn;
     
     # No auth_request for favicon    
     location = /favicon.ico {
@@ -85,8 +85,8 @@ server {
  
     # We need this logging for inspecting auth requests from other internal services
     # Logging to the mounted volume for outside container access
-    access_log /home/hubmap/logs/nginx_access_uuid-api-server.log;
-    error_log /home/hubmap/logs/nginx_error_uuid-api-server.log warn;
+    access_log /usr/src/app/log/nginx_access_uuid-api-server.log;
+    error_log /usr/src/app/log/nginx_error_uuid-api-server.log warn;
     
     location = /favicon.ico {
         alias /usr/share/nginx/html/favicon.ico;

--- a/nginx/conf.d-dev/uuid-api.conf
+++ b/nginx/conf.d-dev/uuid-api.conf
@@ -11,8 +11,8 @@ server {
     root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_uuid-api.log;
-    error_log /usr/src/app/log/nginx_error_uuid-api.log warn;
+    access_log /home/hubmap/logs/nginx_access_uuid-api.log;
+    error_log /home/hubmap/logs/nginx_error_uuid-api.log warn;
     
     # No auth_request for favicon    
     location = /favicon.ico {
@@ -85,8 +85,8 @@ server {
  
     # We need this logging for inspecting auth requests from other internal services
     # Logging to the mounted volume for outside container access
-    access_log /usr/src/app/log/nginx_access_uuid-api-server.log;
-    error_log /usr/src/app/log/nginx_error_uuid-api-server.log warn;
+    access_log /home/hubmap/logs/nginx_access_uuid-api-server.log;
+    error_log /home/hubmap/logs/nginx_error_uuid-api-server.log warn;
     
     location = /favicon.ico {
         alias /usr/share/nginx/html/favicon.ico;

--- a/nginx/conf.d-dev/uuid-api.conf
+++ b/nginx/conf.d-dev/uuid-api.conf
@@ -3,8 +3,10 @@ upstream uuid-api-server {
     server localhost:9999;
 }
 
+# Port 8282 on host maps to 8282 on container
 server {
-    # The port exposed on `hubmap-auth` container for nginx
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8282;
     
     server_name localhost;
@@ -77,7 +79,11 @@ server {
 
 
 # uuid-api-server
+# `http://hubmap-auth:9999` can be used by other contianers (entity-api, ingest-api) 
+# to make calls to uuid-api directly bypassing gateway
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 9999;
     
     server_name localhost;

--- a/nginx/conf.d-prod/assets.conf
+++ b/nginx/conf.d-prod/assets.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name assets.hubmapconsortium.org;
     
     location / {
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name assets.hubmapconsortium.org;
     
     root /usr/src/assets;

--- a/nginx/conf.d-prod/assets.conf
+++ b/nginx/conf.d-prod/assets.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name assets.hubmapconsortium.org;
     
@@ -8,8 +10,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name assets.hubmapconsortium.org;
     
     root /usr/src/assets;

--- a/nginx/conf.d-prod/entity-api.conf
+++ b/nginx/conf.d-prod/entity-api.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name entity.api.hubmapconsortium.org;
     
     location / {
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name entity.api.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-prod/entity-api.conf
+++ b/nginx/conf.d-prod/entity-api.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name entity.api.hubmapconsortium.org;
     
@@ -8,8 +10,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name entity.api.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-prod/hubmap-auth.conf
+++ b/nginx/conf.d-prod/hubmap-auth.conf
@@ -3,12 +3,12 @@
 # We have to run the hubmap-auth service on a different local port to be used by other APIs
 # when deployed with multiple sub-domains pointing to the same machine with same IP
 upstream hubmap-auth-server {
-    server localhost:8080;
+    server localhost:80;
 }
 
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name gateway.hubmapconsortium.org;
     
     location / {
@@ -16,9 +16,9 @@ server {
     }    
 }
 
-# SSL on port 443
+# SSL on port 9443
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 9443 ssl; # managed by Certbot
     server_name gateway.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 
@@ -72,8 +72,8 @@ server {
 
 # hubmap-auth service
 server {
-    # The hubmap-auth service listens to port 8080 on the same container
-    listen 8080;
+    # The hubmap-auth service listens to port 80 on the same container
+    listen 80;
     
     server_name localhost;
     root /usr/share/nginx/html;

--- a/nginx/conf.d-prod/hubmap-auth.conf
+++ b/nginx/conf.d-prod/hubmap-auth.conf
@@ -3,11 +3,13 @@
 # We have to run the hubmap-auth service on a different local port to be used by other APIs
 # when deployed with multiple sub-domains pointing to the same machine with same IP
 upstream hubmap-auth-server {
-    server localhost:80;
+    server localhost:8000;
 }
 
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name gateway.hubmapconsortium.org;
     
@@ -16,9 +18,11 @@ server {
     }    
 }
 
-# SSL on port 9443
+# Port 443 on host maps to 4430 on container
 server {
-    listen 9443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name gateway.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 
@@ -43,8 +47,11 @@ server {
     }
 }
 
-# SSL on port 8443 for ingest-api on another machine
+# Port 8443 on host maps to 8443 on container
+# Port 8443 is used by ingest-api on another machine for auth_request
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8443 ssl; # managed by Certbot
     server_name gateway.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
@@ -72,8 +79,9 @@ server {
 
 # hubmap-auth service
 server {
-    # The hubmap-auth service listens to port 80 on the same container
-    listen 80;
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 8000;
     
     server_name localhost;
     root /usr/share/nginx/html;

--- a/nginx/conf.d-prod/ingest-ui.conf
+++ b/nginx/conf.d-prod/ingest-ui.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name ingest.hubmapconsortium.org;
     
@@ -8,8 +10,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name ingest.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-prod/ingest-ui.conf
+++ b/nginx/conf.d-prod/ingest-ui.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name ingest.hubmapconsortium.org;
     
     location / {
@@ -8,9 +8,8 @@ server {
     }    
 }
 
-# TO-DO: generate SSL cert for this subdomain
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name ingest.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-prod/ingest-ui.conf
+++ b/nginx/conf.d-prod/ingest-ui.conf
@@ -23,7 +23,8 @@ server {
     error_log /usr/src/app/log/nginx_error_ingest-ui.log warn;
 
     location / {
-        proxy_pass http://ingest-ui;
+        # ingest-ui nginx runs as non-root, using port 8080
+        proxy_pass http://ingest-ui:8080;
     }
 
 }

--- a/nginx/conf.d-prod/uuid-api.conf
+++ b/nginx/conf.d-prod/uuid-api.conf
@@ -3,8 +3,10 @@ upstream uuid-api-server {
     server localhost:9999;
 }
 
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name uuid.api.hubmapconsortium.org;
     
@@ -13,8 +15,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name uuid.api.hubmapconsortium.org;
     root /usr/share/nginx/html;
 
@@ -91,7 +96,11 @@ server {
 }
 
 # uuid-api-server
+# `http://hubmap-auth:9999` can be used by other contianers (entity-api, ingest-api) 
+# to make calls to uuid-api directly bypassing gateway
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 9999;
     
     server_name localhost;

--- a/nginx/conf.d-prod/uuid-api.conf
+++ b/nginx/conf.d-prod/uuid-api.conf
@@ -5,7 +5,7 @@ upstream uuid-api-server {
 
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name uuid.api.hubmapconsortium.org;
     
     location / {
@@ -14,7 +14,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name uuid.api.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/assets.conf
+++ b/nginx/conf.d-test/assets.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name assets.test.hubmapconsortium.org;
     
@@ -8,9 +10,11 @@ server {
     }    
 }
 
-# SSL on port 8443
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name assets.test.hubmapconsortium.org;
     
     # This directory will be mountes from host to docker

--- a/nginx/conf.d-test/assets.conf
+++ b/nginx/conf.d-test/assets.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name assets.test.hubmapconsortium.org;
     
     location / {
@@ -8,9 +8,9 @@ server {
     }    
 }
 
-# SSL on port 443
+# SSL on port 8443
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name assets.test.hubmapconsortium.org;
     
     # This directory will be mountes from host to docker

--- a/nginx/conf.d-test/entity-api.conf
+++ b/nginx/conf.d-test/entity-api.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name entity-api.test.hubmapconsortium.org;
     
@@ -8,8 +10,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name entity-api.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/entity-api.conf
+++ b/nginx/conf.d-test/entity-api.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name entity-api.test.hubmapconsortium.org;
     
     location / {
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name entity-api.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/hubmap-auth.conf
+++ b/nginx/conf.d-test/hubmap-auth.conf
@@ -3,12 +3,12 @@
 # We have to run the hubmap-auth service on a different local port to be used by other APIs
 # when deployed with multiple sub-domains pointing to the same machine with same IP
 upstream hubmap-auth-server {
-    server localhost:8080;
+    server localhost:80;
 }
 
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name gateway.test.hubmapconsortium.org;
     
     location / {
@@ -16,9 +16,9 @@ server {
     }    
 }
 
-# SSL on port 443
+# SSL on port 9443
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 9443 ssl; # managed by Certbot
     server_name gateway.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 
@@ -72,8 +72,8 @@ server {
 
 # hubmap-auth service
 server {
-    # The hubmap-auth service listens to port 8080 on the same container
-    listen 8080;
+    # The hubmap-auth service listens to port 80 on the same container
+    listen 80;
     
     server_name localhost;
     root /usr/share/nginx/html;

--- a/nginx/conf.d-test/hubmap-auth.conf
+++ b/nginx/conf.d-test/hubmap-auth.conf
@@ -3,11 +3,13 @@
 # We have to run the hubmap-auth service on a different local port to be used by other APIs
 # when deployed with multiple sub-domains pointing to the same machine with same IP
 upstream hubmap-auth-server {
-    server localhost:80;
+    server localhost:8000;
 }
 
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name gateway.test.hubmapconsortium.org;
     
@@ -16,9 +18,11 @@ server {
     }    
 }
 
-# SSL on port 9443
+# Port 443 on host maps to 4430 on container
 server {
-    listen 9443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name gateway.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 
@@ -43,8 +47,11 @@ server {
     }
 }
 
-# SSL on port 8443 for ingest-api on another machine
+# Port 8443 on host maps to 8443 on container
+# Port 8443 is used by ingest-api on another machine for auth_request
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8443 ssl; # managed by Certbot
     server_name gateway.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
@@ -72,8 +79,9 @@ server {
 
 # hubmap-auth service
 server {
-    # The hubmap-auth service listens to port 80 on the same container
-    listen 80;
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 8000;
     
     server_name localhost;
     root /usr/share/nginx/html;

--- a/nginx/conf.d-test/ingest-ui.conf
+++ b/nginx/conf.d-test/ingest-ui.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name ingest.test.hubmapconsortium.org;
     
@@ -8,8 +10,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name ingest.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/ingest-ui.conf
+++ b/nginx/conf.d-test/ingest-ui.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name ingest.test.hubmapconsortium.org;
     
     location / {
@@ -8,9 +8,8 @@ server {
     }    
 }
 
-# TO-DO: generate SSL cert for this subdomain
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name ingest.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/ingest-ui.conf
+++ b/nginx/conf.d-test/ingest-ui.conf
@@ -23,7 +23,8 @@ server {
     error_log /usr/src/app/log/nginx_error_ingest-ui.log warn;
 
     location / {
-        proxy_pass http://ingest-ui;
+        # ingest-ui nginx runs as non-root, using port 8080
+        proxy_pass http://ingest-ui:8080;
     }
 
 }

--- a/nginx/conf.d-test/portal-ui.conf
+++ b/nginx/conf.d-test/portal-ui.conf
@@ -1,5 +1,7 @@
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name portal.test.hubmapconsortium.org;
     
@@ -8,8 +10,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name portal.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/portal-ui.conf
+++ b/nginx/conf.d-test/portal-ui.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name portal.test.hubmapconsortium.org;
     
     location / {
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name portal.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/nginx/conf.d-test/uuid-api.conf
+++ b/nginx/conf.d-test/uuid-api.conf
@@ -3,8 +3,10 @@ upstream uuid-api-server {
     server localhost:9999;
 }
 
-# Subdomain resolve
+# Port 80 on host maps to 8080 on container
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 8080;
     server_name uuid-api.test.hubmapconsortium.org;
     
@@ -13,8 +15,11 @@ server {
     }    
 }
 
+# Port 443 on host maps to 4430 on container
 server {
-    listen 8443 ssl; # managed by Certbot
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
+    listen 4430 ssl; # managed by Certbot
     server_name uuid-api.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 
@@ -91,7 +96,11 @@ server {
 }
 
 # uuid-api-server
+# `http://hubmap-auth:9999` can be used by other contianers (entity-api, ingest-api) 
+# to make calls to uuid-api directly bypassing gateway
 server {
+    # Only root can listen on ports below 1024, we use higher-numbered ports
+    # since nginx is running under non-root user hubmap
     listen 9999;
     
     server_name localhost;

--- a/nginx/conf.d-test/uuid-api.conf
+++ b/nginx/conf.d-test/uuid-api.conf
@@ -5,7 +5,7 @@ upstream uuid-api-server {
 
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name uuid-api.test.hubmapconsortium.org;
     
     location / {
@@ -14,7 +14,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name uuid-api.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 


### PR DESCRIPTION
This PR:

- de-elevates root to hubmap user (mapped with the host UID and GID) for running nginx, uwsgi and docker processes
- the docker-compose takes UID and GID as new environment variables for passing host user info to docker container
- internal ports changes to allow nginx run as non-root process