### PR TITLE
Upgrade proxy_http_version for portal-ui nginx conf

### DIFF
--- a/nginx/conf.d-dev/portal-ui.conf
+++ b/nginx/conf.d-dev/portal-ui.conf
@@ -40,6 +40,10 @@ server {
         # (Plain "$host" does not include port.)
         proxy_set_header  Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # gzip_http_version sets the minimum HTTP version of a request required to compress a response to 1.1 by default.
+        # proxy_http_version needs to be >= that, but is 1.0 by default.
+        proxy_http_version  1.1;
     }
 
 }


### PR DESCRIPTION
Updates nginx configuration. Once this change is made we should see `Content-Encoding: gzip` in the response headers for portal webpack assets.

> gzip_http_version sets the minimum HTTP version of a request required to compress a response to 1.1 by default.
> proxy_http_version needs to be >= that, but is 1.0 by default.