### PR TITLE
added ingest-api Upload methods

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -392,6 +392,30 @@
       "auth": false
     },
     {
+      "method": "POST",
+      "endpoint": "/uploads",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/validate",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/arrange-into-datasets",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },      
+    {
       "method": "GET",
       "endpoint": "/metadata/usergroups",
       "auth": false

--- a/api_endpoints.localhost.json
+++ b/api_endpoints.localhost.json
@@ -392,6 +392,30 @@
       "auth": false
     },
     {
+      "method": "POST",
+      "endpoint": "/uploads",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/validate",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/arrange-into-datasets",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },      
+    {
       "method": "GET",
       "endpoint": "/metadata/usergroups",
       "auth": false

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -392,6 +392,30 @@
       "auth": false
     },
     {
+      "method": "POST",
+      "endpoint": "/uploads",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/validate",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/arrange-into-datasets",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/metadata/usergroups",
       "auth": false

--- a/api_endpoints.stage.json
+++ b/api_endpoints.stage.json
@@ -392,6 +392,30 @@
       "auth": false
     },
     {
+      "method": "POST",
+      "endpoint": "/uploads",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/validate",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/arrange-into-datasets",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/metadata/usergroups",
       "auth": false

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -392,6 +392,30 @@
       "auth": false
     },
     {
+      "method": "POST",
+      "endpoint": "/uploads",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/validate",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/uploads/<*>/arrange-into-datasets",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/metadata/usergroups",
       "auth": false


### PR DESCRIPTION
Following https://github.com/hubmapconsortium/gateway/pull/91

Note: the `PUT /uploads/<*>/arrange-into-datasets` call has not been implemented in ingest-api