### PR TITLE
Derek furst/update endpoints

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -73,6 +73,14 @@
       "auth": false
     },
     {
+      "method": "PUT",
+      "endpoint": "/datasets/<*>/retract",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false

--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -69,6 +69,11 @@
     },
     {
       "method": "GET",
+      "endpoint": "/datasets/<*>/revisions",
+      "auth": false
+    },
+    {
+      "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false
     },

--- a/api_endpoints.localhost.json
+++ b/api_endpoints.localhost.json
@@ -69,6 +69,11 @@
     },
     {
       "method": "GET",
+      "endpoint": "/datasets/<*>/revisions",
+      "auth": false
+    },
+    {
+      "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false
     },

--- a/api_endpoints.localhost.json
+++ b/api_endpoints.localhost.json
@@ -68,6 +68,14 @@
       "auth": false
     },
     {
+      "method": "PUT",
+      "endpoint": "/datasets/<*>/retract",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/datasets/<*>/revisions",
       "auth": false

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -69,6 +69,11 @@
     },
     {
       "method": "GET",
+      "endpoint": "/datasets/<*>/revisions",
+      "auth": false
+    },
+    {
+      "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false
     },

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -68,6 +68,14 @@
       "auth": false
     },
     {
+      "method": "PUT",
+      "endpoint": "/datasets/<*>/retract",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/datasets/<*>/revisions",
       "auth": false

--- a/api_endpoints.stage.json
+++ b/api_endpoints.stage.json
@@ -69,6 +69,11 @@
     },
     {
       "method": "GET",
+      "endpoint": "/datasets/<*>/revisions",
+      "auth": false
+    },
+    {
+      "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false
     },

--- a/api_endpoints.stage.json
+++ b/api_endpoints.stage.json
@@ -68,6 +68,14 @@
       "auth": false
     },
     {
+      "method": "PUT",
+      "endpoint": "/datasets/<*>/retract",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/datasets/<*>/revisions",
       "auth": false

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -73,6 +73,14 @@
       "auth": false
     },
     {
+      "method": "PUT",
+      "endpoint": "/datasets/<*>/retract",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
       "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -69,6 +69,11 @@
     },
     {
       "method": "GET",
+      "endpoint": "/datasets/<*>/revisions",
+      "auth": false
+    },
+    {
+      "method": "GET",
       "endpoint": "/favicon.ico",
       "auth": false
     },


### PR DESCRIPTION
New endpoints for datasets/revisions and datasets/retract on entity api. no auth for revisions, hubmap data-admin for retract. 