### PR TITLE
Use 5031 and 5032 for maintenance ports

### DIFF
--- a/nginx/conf.d-dev/ingest-ui.conf
+++ b/nginx/conf.d-dev/ingest-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/ingest-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:5555;
+            proxy_pass http://127.0.0.1:5032;
         }
         
         # ingest-ui nginx runs as non-root, using port 8080
@@ -42,12 +42,12 @@ server {
 }
 
 
-# Port 5555 runs the ingest-ui-maintenance static page index.html
+# Port 5032 runs the ingest-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 5555;
+    listen 5032;
     
     server_name localhost;
 

--- a/nginx/conf.d-dev/portal-ui.conf
+++ b/nginx/conf.d-dev/portal-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/portal-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:8888;
+            proxy_pass http://127.0.0.1:5031;
         }
 
         proxy_pass http://portal-ui;
@@ -57,12 +57,12 @@ server {
 }
 
 
-# Port 8888 runs the portal-ui-maintenance static page index.html
+# Port 5031 runs the portal-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 8888;
+    listen 5031;
     
     server_name localhost;
 

--- a/nginx/conf.d-dev/spatial-api.conf
+++ b/nginx/conf.d-dev/spatial-api.conf
@@ -3,7 +3,9 @@ server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
     listen 8888;
+    
     server_name localhost;
+    root /usr/share/nginx/html;
 
     # Logging to the mounted volume for outside container access
     access_log /usr/src/app/log/nginx_access_spatial-api.log;

--- a/nginx/conf.d-dev/workspaces-api.conf
+++ b/nginx/conf.d-dev/workspaces-api.conf
@@ -1,3 +1,4 @@
+# Port 7777 on host maps to 7777 on container
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap

--- a/nginx/conf.d-localhost/ingest-ui.conf
+++ b/nginx/conf.d-localhost/ingest-ui.conf
@@ -14,7 +14,7 @@ server {
         # If the file named `maintenance.on` exitis under the target directory
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/ingest-ui-maintenance/maintenance.on) {
-            proxy_pass http://localhost:5555;
+            proxy_pass http://localhost:5032;
         }
 
         # ingest-ui nginx runs as non-root, using port 8080
@@ -23,12 +23,12 @@ server {
 }
 
 
-# Port 5555 runs the ingest-ui-maintenance static page index.html
+# Port 5032 runs the ingest-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 5555;
+    listen 5032;
     
     server_name localhost;
 

--- a/nginx/conf.d-prod/ingest-ui.conf
+++ b/nginx/conf.d-prod/ingest-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/ingest-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:5555;
+            proxy_pass http://127.0.0.1:5032;
         }
         
         # ingest-ui nginx runs as non-root, using port 8080
@@ -42,12 +42,12 @@ server {
 }
 
 
-# Port 5555 runs the ingest-ui-maintenance static page index.html
+# Port 5032 runs the ingest-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 5555;
+    listen 5032;
     
     server_name localhost;
 

--- a/nginx/conf.d-prod/portal-ui.conf
+++ b/nginx/conf.d-prod/portal-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/portal-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:8888;
+            proxy_pass http://127.0.0.1:5031;
         }
 
         proxy_pass http://portal-ui;
@@ -57,12 +57,12 @@ server {
 }
 
 
-# Port 8888 runs the portal-ui-maintenance static page index.html
+# Port 5031 runs the portal-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 8888;
+    listen 5031;
     
     server_name localhost;
 

--- a/nginx/conf.d-prod/workspaces-api.conf
+++ b/nginx/conf.d-prod/workspaces-api.conf
@@ -1,3 +1,4 @@
+# Port 7777 on host maps to 7777 on container
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap

--- a/nginx/conf.d-stage/ingest-ui.conf
+++ b/nginx/conf.d-stage/ingest-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/ingest-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:5555;
+            proxy_pass http://127.0.0.1:5032;
         }
         
         # ingest-ui nginx runs as non-root, using port 8080
@@ -42,12 +42,12 @@ server {
 }
 
 
-# Port 5555 runs the ingest-ui-maintenance static page index.html
+# Port 5032 runs the ingest-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 5555;
+    listen 5032;
     
     server_name localhost;
 

--- a/nginx/conf.d-stage/portal-ui.conf
+++ b/nginx/conf.d-stage/portal-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/portal-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:8888;
+            proxy_pass http://127.0.0.1:5031;
         }
 
         proxy_pass http://portal-ui;
@@ -57,12 +57,12 @@ server {
 }
 
 
-# Port 8888 runs the portal-ui-maintenance static page index.html
+# Port 5031 runs the portal-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 8888;
+    listen 5031;
     
     server_name localhost;
 

--- a/nginx/conf.d-test/ingest-ui.conf
+++ b/nginx/conf.d-test/ingest-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/ingest-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:5555;
+            proxy_pass http://127.0.0.1:5032;
         }
         
         # ingest-ui nginx runs as non-root, using port 8080
@@ -42,12 +42,12 @@ server {
 }
 
 
-# Port 5555 runs the ingest-ui-maintenance static page index.html
+# Port 5032 runs the ingest-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 5555;
+    listen 5032;
     
     server_name localhost;
 

--- a/nginx/conf.d-test/portal-ui.conf
+++ b/nginx/conf.d-test/portal-ui.conf
@@ -32,7 +32,7 @@ server {
         # proxy all the requests to that port of this same container that serves the maintenance page
         if (-f /usr/share/nginx/html/portal-ui-maintenance/maintenance.on) {
             # Use IP v4 "127.0.0.1" instead of "localhost" to avoid 502 error caused by DNS failure
-            proxy_pass http://127.0.0.1:8888;
+            proxy_pass http://127.0.0.1:5031;
         }
 
         proxy_pass http://portal-ui;
@@ -57,12 +57,12 @@ server {
 }
 
 
-# Port 8888 runs the portal-ui-maintenance static page index.html
+# Port 5031 runs the portal-ui-maintenance static page index.html
 # No need to public this port from the container to host
 server {
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
-    listen 8888;
+    listen 5031;
     
     server_name localhost;
 


### PR DESCRIPTION
Due to portal-ui maintenance port 8888 conflicting with the spatial-api port 8888, changed to use 5031 and 5032 for portal-ui and ingest-ui maintenance ports. Inspired by 503 Service Unavailable