### PR TITLE
Renaming endpoint from notify-slack to notify, in coordination with ingest-api changes

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -17,7 +17,7 @@
     },
     {
       "method": "POST",
-      "endpoint": "/notify-slack",
+      "endpoint": "/notify",
       "auth": true,
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -17,7 +17,7 @@
     },
     {
       "method": "POST",
-      "endpoint": "/notify-slack",
+      "endpoint": "/notify",
       "auth": true,
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"

--- a/api_endpoints.stage.json
+++ b/api_endpoints.stage.json
@@ -17,7 +17,7 @@
     },
     {
       "method": "POST",
-      "endpoint": "/notify-slack",
+      "endpoint": "/notify",
       "auth": true,
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -17,7 +17,7 @@
     },
     {
       "method": "POST",
-      "endpoint": "/notify-slack",
+      "endpoint": "/notify",
       "auth": true,
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"


### PR DESCRIPTION
Renaming endpoint from notify-slack to notify, in coordination with ingest-api changes