### PR TITLE
Added endpoint ingest-api datasets/metadata-json

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -134,6 +134,14 @@
     },
     {
       "method": "PUT",
+      "endpoint": "/datasets/metadata-json",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
+      "method": "PUT",
       "endpoint": "/datasets/<*>/submit",
       "auth": true,
       "groups": [

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -134,6 +134,14 @@
     },
     {
       "method": "PUT",
+      "endpoint": "/datasets/metadata-json",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
+      "method": "PUT",
       "endpoint": "/datasets/<*>/submit",
       "auth": true,
       "groups": [

--- a/api_endpoints.stage.json
+++ b/api_endpoints.stage.json
@@ -134,6 +134,14 @@
     },
     {
       "method": "PUT",
+      "endpoint": "/datasets/metadata-json",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
+      "method": "PUT",
       "endpoint": "/datasets/<*>/submit",
       "auth": true,
       "groups": [

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -134,6 +134,14 @@
     },
     {
       "method": "PUT",
+      "endpoint": "/datasets/metadata-json",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
+    },
+    {
+      "method": "PUT",
       "endpoint": "/datasets/<*>/submit",
       "auth": true,
       "groups": [


### PR DESCRIPTION
To support this new create metadata.json endpoint by adding it to api_endpoints.<dev|test|stage|prod>.json file under the ingest-api section. The data-admin group uuid is 89a69625-99d7-11ea-9366-0e98982705c1.