### PR TITLE
Yuanzhou/soft assay types

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -94,13 +94,13 @@
       "auth": false
     },
     {
-      "method": "POST",
-      "endpoint": "/dataset/begin-extract-cell-count-from-secondary-analysis-files-async",
+      "method": "GET",
+      "endpoint": "/uploads/<*>/file-system-abs-path",
       "auth": false
     },
     {
-      "method": "GET",
-      "endpoint": "/uploads/<*>/file-system-abs-path",
+      "method": "POST",
+      "endpoint": "/dataset/begin-extract-cell-count-from-secondary-analysis-files-async",
       "auth": false
     },
     {
@@ -147,7 +147,7 @@
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"
       ]
-    },
+    },      
     {
       "method": "PUT",
       "endpoint": "/datasets/<*>/unpublish",
@@ -260,7 +260,7 @@
       "auth": true,
       "groups": [
         "89a69625-99d7-11ea-9366-0e98982705c1"
-      ]	
+      ] 
     },
     {
       "method": "PUT",
@@ -402,7 +402,7 @@
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"
       ]
-    },    
+    },
     {
       "method": "GET",
       "endpoint": "/specimens/<*>",
@@ -494,6 +494,30 @@
       "method": "GET",
       "endpoint": "/data-ingest-board-logout",
       "auth": false
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype/<*>",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/reload",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
     }
   ],
   "avr.dev.hubmapconsortium.org": [

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -494,6 +494,30 @@
       "method": "GET",
       "endpoint": "/data-ingest-board-logout",
       "auth": false
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype/<*>",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/reload",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
+      ]
     }
   ],
   "avr.hubmapconsortium.org": [

--- a/api_endpoints.stage.json
+++ b/api_endpoints.stage.json
@@ -94,13 +94,13 @@
       "auth": false
     },
     {
-      "method": "POST",
-      "endpoint": "/dataset/begin-extract-cell-count-from-secondary-analysis-files-async",
+      "method": "GET",
+      "endpoint": "/uploads/<*>/file-system-abs-path",
       "auth": false
     },
     {
-      "method": "GET",
-      "endpoint": "/uploads/<*>/file-system-abs-path",
+      "method": "POST",
+      "endpoint": "/dataset/begin-extract-cell-count-from-secondary-analysis-files-async",
       "auth": false
     },
     {
@@ -215,26 +215,6 @@
       "auth": false
     },
     {
-      "method": "GET",
-      "endpoint": "/datasets/data-status",
-      "auth": false
-    },
-    {
-      "method": "GET",
-      "endpoint": "/uploads/data-status",
-      "auth": false
-    },
-    {
-      "method": "GET",
-      "endpoint": "/data-ingest-board-login",
-      "auth": false
-    },
-    {
-      "method": "GET",
-      "endpoint": "/data-ingest-board-logout",
-      "auth": false
-    },
-    {
       "method": "POST",
       "endpoint": "/file-upload",
       "auth": true,
@@ -280,7 +260,7 @@
       "auth": true,
       "groups": [
         "89a69625-99d7-11ea-9366-0e98982705c1"
-      ]	
+      ] 
     },
     {
       "method": "PUT",
@@ -493,6 +473,50 @@
       "auth": true,
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "GET",
+      "endpoint": "/datasets/data-status",
+      "auth": false
+    },
+    {
+      "method": "GET",
+      "endpoint": "/uploads/data-status",
+      "auth": false
+    },
+    {
+      "method": "GET",
+      "endpoint": "/data-ingest-board-login",
+      "auth": false
+    },
+    {
+      "method": "GET",
+      "endpoint": "/data-ingest-board-logout",
+      "auth": false
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype/<*>",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/reload",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
       ]
     }
   ]

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -89,13 +89,13 @@
       "auth": false
     },
     {
-      "method": "GET",
-      "endpoint": "/uploads/<*>/file-system-abs-path",
+      "method": "POST",
+      "endpoint": "/entities/file-system-rel-path",
       "auth": false
     },
     {
-      "method": "POST",
-      "endpoint": "/entities/file-system-rel-path",
+      "method": "GET",
+      "endpoint": "/uploads/<*>/file-system-abs-path",
       "auth": false
     },
     {
@@ -215,26 +215,6 @@
       "auth": false
     },
     {
-      "method": "GET",
-      "endpoint": "/datasets/data-status",
-      "auth": false
-    },
-    {
-      "method": "GET",
-      "endpoint": "/uploads/data-status",
-      "auth": false
-    },
-    {
-      "method": "GET",
-      "endpoint": "/data-ingest-board-login",
-      "auth": false
-    },
-    {
-      "method": "GET",
-      "endpoint": "/data-ingest-board-logout",
-      "auth": false
-    },
-    {
       "method": "POST",
       "endpoint": "/file-upload",
       "auth": true,
@@ -280,7 +260,7 @@
       "auth": true,
       "groups": [
         "89a69625-99d7-11ea-9366-0e98982705c1"
-      ]	
+      ] 
     },
     {
       "method": "PUT",
@@ -493,6 +473,50 @@
       "auth": true,
       "groups": [
         "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "GET",
+      "endpoint": "/datasets/data-status",
+      "auth": false
+    },
+    {
+      "method": "GET",
+      "endpoint": "/uploads/data-status",
+      "auth": false
+    },
+    {
+      "method": "GET",
+      "endpoint": "/data-ingest-board-login",
+      "auth": false
+    },
+    {
+      "method": "GET",
+      "endpoint": "/data-ingest-board-logout",
+      "auth": false
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "POST",
+      "endpoint": "/assaytype/<*>",
+      "auth": true,
+      "groups": [
+        "5777527e-ec11-11e8-ab41-0af86edb4424"
+      ]
+    },
+    {
+      "method": "PUT",
+      "endpoint": "/reload",
+      "auth": true,
+      "groups": [
+        "89a69625-99d7-11ea-9366-0e98982705c1"
       ]
     }
   ]


### PR DESCRIPTION
3 new endpoints to support the initial work of soft assay types: https://github.com/hubmapconsortium/ingest-api/pull/380

```
POST /assaytype requires HuBMAP-Read group token
GET /assaytype/<ds_uuid> requires HuBMAP-Read group token
PUT /reload requires HuBMAP-Data-Admin group token
```