### PR TITLE
Remove datasets/status endpoint from gateway and Ingest API

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -64,11 +64,6 @@
       ]
     },
     {
-      "method": "PUT",
-      "endpoint": "/datasets/status",
-      "auth": false
-    },
-    {
       "method": "GET",
       "endpoint": "/entities/<*>",
       "auth": false

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -64,11 +64,6 @@
       ]
     },
     {
-      "method": "PUT",
-      "endpoint": "/datasets/status",
-      "auth": false
-    },
-    {
       "method": "GET",
       "endpoint": "/entities/<*>",
       "auth": false

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -64,11 +64,6 @@
       ]
     },
     {
-      "method": "PUT",
-      "endpoint": "/datasets/status",
-      "auth": false
-    },
-    {
       "method": "GET",
       "endpoint": "/entities/<*>",
       "auth": false


### PR DESCRIPTION
Remove datasets/status endpoint from gateway and Ingest API, to go with  [Issue 555](https://github.com/hubmapconsortium/ingest-api/issues/555) and [Pull 620](https://github.com/hubmapconsortium/ingest-api/pull/620).