### PR TITLE
Move authorization checks for /entities/accessible-data-directories endpoint

### DIFF
--- a/api_endpoints.dev.json
+++ b/api_endpoints.dev.json
@@ -101,10 +101,7 @@
     {
       "method": "POST",
       "endpoint": "/entities/accessible-data-directories",
-      "auth": true,
-      "groups": [
-        "5777527e-ec11-11e8-ab41-0af86edb4424"
-      ]
+      "auth": false
     },
     {
       "method": "GET",

--- a/api_endpoints.prod.json
+++ b/api_endpoints.prod.json
@@ -101,10 +101,7 @@
     {
       "method": "POST",
       "endpoint": "/entities/accessible-data-directories",
-      "auth": true,
-      "groups": [
-        "5777527e-ec11-11e8-ab41-0af86edb4424"
-      ]
+      "auth": false
     },
     {
       "method": "GET",

--- a/api_endpoints.test.json
+++ b/api_endpoints.test.json
@@ -101,10 +101,7 @@
     {
       "method": "POST",
       "endpoint": "/entities/accessible-data-directories",
-      "auth": true,
-      "groups": [
-        "5777527e-ec11-11e8-ab41-0af86edb4424"
-      ]
+      "auth": false
     },
     {
       "method": "GET",


### PR DESCRIPTION
Restore authorization checks for /entities/accessible-data-directories endpoint, in coordination with removing AWS Gateway authorization.